### PR TITLE
Add a new endpoint for downloading usage metrics reports

### DIFF
--- a/api.raml
+++ b/api.raml
@@ -73,7 +73,20 @@ securitySchemes:
         body:
           application/json:
             type: lib.UserAnalysisMetricsResponse
-      
+
+  /reports:
+    displayName: Get usage metrics for EDA users by time period
+    get:
+      queryParameters:
+        reportMonth:
+          description: optional report month (yyyy-mm)
+          type: string
+      responses:
+        200:
+          body:
+            application/zip:
+              type: lib.MetricsReportResponse
+
 /users/{user-id}:
 
   /preferences/{project-id}:

--- a/api.raml
+++ b/api.raml
@@ -75,11 +75,11 @@ securitySchemes:
             type: lib.UserAnalysisMetricsResponse
 
   /reports:
-    displayName: Get usage metrics for EDA users by time period
+    displayName: Download usage metric reports for a given month
     get:
       queryParameters:
         reportMonth:
-          description: optional report month (yyyy-mm)
+          description: Required report month (yyyy-mm)
           type: string
       responses:
         200:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -152,6 +152,7 @@ dependencies {
   // Utils
   implementation("io.vulpine.lib:Jackfish:1.1.0")
   implementation("com.devskiller.friendly-id:friendly-id:1.1.0")
+  implementation("org.kamranzafar:jtar:2.2")
 
   // Unit Testing
   testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.2")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -152,7 +152,6 @@ dependencies {
   // Utils
   implementation("io.vulpine.lib:Jackfish:1.1.0")
   implementation("com.devskiller.friendly-id:friendly-id:1.1.0")
-  implementation("org.kamranzafar:jtar:2.2")
 
   // Unit Testing
   testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.2")

--- a/schema/library.raml
+++ b/schema/library.raml
@@ -714,4 +714,9 @@ types:
     properties:
       objectsCount: integer
       usersCount: integer
+  MetricsReportResponse:
+    type: object
+    additionalProperties: false
+    properties:
+      count: integer
 

--- a/schema/url/user.raml
+++ b/schema/url/user.raml
@@ -180,3 +180,8 @@ types:
     properties:
       objectsCount: integer
       usersCount: integer
+
+  MetricsReportResponse:
+    additionalProperties: false
+    properties:
+      count: integer

--- a/src/main/java/org/veupathdb/service/eda/us/Resources.java
+++ b/src/main/java/org/veupathdb/service/eda/us/Resources.java
@@ -9,6 +9,7 @@ import org.apache.logging.log4j.Logger;
 import org.gusdb.fgputil.FormatUtil;
 import org.gusdb.fgputil.db.platform.DBPlatform;
 import org.gusdb.fgputil.db.platform.Oracle;
+import org.gusdb.fgputil.runtime.Environment;
 import org.gusdb.fgputil.runtime.ProjectSpecificProperties;
 import org.gusdb.fgputil.runtime.ProjectSpecificProperties.PropertySpec;
 import org.veupathdb.lib.container.jaxrs.config.Options;
@@ -88,7 +89,7 @@ public class Resources extends ContainerResources {
   }
 
   public static String getMetricsReportSchema() {
-    return Optional.ofNullable(System.getenv("USAGE_METRICS_SCHEMA")).orElse("usagemetrics.");
+    return Environment.getOptionalVar("USAGE_METRICS_SCHEMA", "usagemetrics.");
   }
 
   /**

--- a/src/main/java/org/veupathdb/service/eda/us/Resources.java
+++ b/src/main/java/org/veupathdb/service/eda/us/Resources.java
@@ -1,6 +1,8 @@
 package org.veupathdb.service.eda.us;
 
 import java.util.Map;
+import java.util.Optional;
+
 import jakarta.ws.rs.NotFoundException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -83,6 +85,10 @@ public class Resources extends ContainerResources {
 
   public static DBPlatform getUserPlatform() {
     return new Oracle();
+  }
+
+  public static String getMetricsReportSchema() {
+    return Optional.ofNullable(System.getenv("USAGE_METRICS_SCHEMA")).orElse("usagemetrics.");
   }
 
   /**

--- a/src/main/java/org/veupathdb/service/eda/us/model/TabularDataWriter.java
+++ b/src/main/java/org/veupathdb/service/eda/us/model/TabularDataWriter.java
@@ -2,9 +2,11 @@ package org.veupathdb.service.eda.us.model;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 
+/**
+ * Defines an interface to write formatted columnar data.
+ */
 public interface TabularDataWriter {
 
   void write(String... column) throws IOException;
@@ -18,6 +20,10 @@ public interface TabularDataWriter {
     private boolean firstColumnInRow = true;
     private OutputStream outputStream;
 
+    /**
+     * Writes formatted TSV data to an output stream. Note that this takes an output stream instead of a writer for
+     * compatibility with writing to a ZipOutputStream.
+     */
     public TsvFormatter(OutputStream outputStream) {
       this.outputStream = outputStream;
     }

--- a/src/main/java/org/veupathdb/service/eda/us/model/TabularDataWriter.java
+++ b/src/main/java/org/veupathdb/service/eda/us/model/TabularDataWriter.java
@@ -1,0 +1,42 @@
+package org.veupathdb.service.eda.us.model;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+
+public interface TabularDataWriter {
+
+  void write(String... column) throws IOException;
+
+  void nextRecord() throws IOException;
+
+  class TsvFormatter implements TabularDataWriter {
+    private static final byte[] TAB_BYTES = "\t".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] NEW_LINE_BYTES = System.lineSeparator().getBytes(StandardCharsets.UTF_8);
+
+    private boolean firstColumnInRow = true;
+    private OutputStream outputStream;
+
+    public TsvFormatter(OutputStream outputStream) {
+      this.outputStream = outputStream;
+    }
+
+    @Override
+    public void write(String... columns) throws IOException {
+      for (String col: columns) {
+        if (!firstColumnInRow) {
+          outputStream.write(TAB_BYTES);
+        }
+        outputStream.write(col.getBytes(StandardCharsets.UTF_8));
+        firstColumnInRow = false;
+      }
+    }
+
+    @Override
+    public void nextRecord() throws IOException {
+      firstColumnInRow = true;
+      outputStream.write(NEW_LINE_BYTES);
+    }
+  }
+}

--- a/src/main/java/org/veupathdb/service/eda/us/model/UserDataFactory.java
+++ b/src/main/java/org/veupathdb/service/eda/us/model/UserDataFactory.java
@@ -556,7 +556,7 @@ public class UserDataFactory {
             sql,
             "read-analysis-study"
         ).executeQuery(
-            new Integer[]{ month, year },
+            new Object[]{ month, year },
             rs -> {
               while (rs.next()) {
                 try {

--- a/src/main/java/org/veupathdb/service/eda/us/model/UserDataFactory.java
+++ b/src/main/java/org/veupathdb/service/eda/us/model/UserDataFactory.java
@@ -12,6 +12,7 @@ import org.veupathdb.service.eda.generated.model.*;
 import org.veupathdb.service.eda.us.Resources;
 import org.veupathdb.service.eda.us.Utils;
 
+import java.io.IOException;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
@@ -100,9 +101,11 @@ public class UserDataFactory {
   };
 
   private final String _userSchema;
+  private final String _metricsReportsSchema;
 
   public UserDataFactory(String projectId) {
     _userSchema = Resources.getUserDbSchema(projectId);
+    _metricsReportsSchema = Resources.getMetricsReportSchema();
   }
 
   private String addSchema(String sqlConstant) {
@@ -445,16 +448,16 @@ public class UserDataFactory {
 
   public List<StudyCount> readAnalysisCountsByStudy(MetricsUserProjectIdAnalysesGetStudyType studyType, LocalDate startDate, LocalDate endDate, DateColumn dateColumn, String ignoreUserIds, Imported imported) {
     String sqlTemplate = """
-select count(analysis_id) as cnt, study_id
-from %sanalysis a, %susers u
-where %s > ? and %s <= ? %s
-and a.user_id = u.user_id
-and study_id %s
-and a.user_id NOT IN (%s)
-%s
-group by study_id
-order by cnt desc
-        """;
+        select count(analysis_id) as cnt, study_id
+        from %sanalysis a, %susers u
+        where %s > ? and %s <= ? %s
+        and a.user_id = u.user_id
+        and study_id %s
+        and a.user_id NOT IN (%s)
+        %s
+        group by study_id
+        order by cnt desc
+                """;
     String importClause = imported == Imported.YES ? "and provenance is not null" + System.lineSeparator() : "";
     String sql = String.format(sqlTemplate, _userSchema, _userSchema, dateColumn.label, dateColumn.label, dateColumn.andClause,
             getStudyTypeSql(studyType), ignoreUserIds, importClause);
@@ -486,20 +489,20 @@ order by cnt desc
   // the objects are aggregated by the aggregateObjectsSql.  EG:  "count(analysis_id)" or "sum(num_filters)"
   public List<UsersObjectsCount> readObjectCountsByUserCounts(MetricsUserProjectIdAnalysesGetStudyType studyType, String aggregateObjectSql, LocalDate startDate, LocalDate endDate, DateColumn dateColumn, String ignoreIdsString, IsGuest isGuest) {
     String sqlTemplate = """
-  select count(user_id) as user_cnt, objects
-  from (
-    select %s as objects, a.user_id
-    from %sanalysis a, %susers u
-    where %s > ? and %s <= ? %s
-    and a.user_id = u.user_id
-    and study_id %s
-    and a.user_id NOT IN (%s)
-    and is_guest = ?
-    group by a.user_id
-  )
-  group by objects
-  order by objects desc
-  """;
+        select count(user_id) as user_cnt, objects
+        from (
+          select %s as objects, a.user_id
+          from %sanalysis a, %susers u
+          where %s > ? and %s <= ? %s
+          and a.user_id = u.user_id
+          and study_id %s
+          and a.user_id NOT IN (%s)
+          and is_guest = ?
+          group by a.user_id
+        )
+        group by objects
+        order by objects desc
+        """;
 
     String sql = String.format(sqlTemplate, aggregateObjectSql, _userSchema, _userSchema,
             dateColumn.label, dateColumn.label, dateColumn.andClause, getStudyTypeSql(studyType), ignoreIdsString);
@@ -523,6 +526,203 @@ order by cnt desc
                 counts.add(uac);
               }
               return counts;
+            }
+        ), EXCEPTION_HANDLER);
+  }
+
+  public void streamPerStudyAnalysisMetrics(int year, int month, TabularDataWriter tabularFormatter) {
+    String sql = """
+        SELECT 
+          m.dataset_id, 
+          m.analysis_count,  
+          m.shares_count
+        FROM %sanalysismetricsperstudy m
+        JOIN (
+          SELECT MAX(report_id) report_id, report_month, report_year, MAX(report_time) FROM %sreports
+          GROUP BY report_id, report_month, report_year
+          HAVING report_month = ? AND report_year = ?
+        ) r 
+        ON r.report_id = m.report_id
+    """.formatted(_metricsReportsSchema, _metricsReportsSchema);
+    try {
+      tabularFormatter.write("dataset_id", "analysis_count", "shares_count");
+      tabularFormatter.nextRecord();
+    } catch (IOException e) {
+      throw new RuntimeException("Unable to write headers.", e);
+    }
+    mapException(() ->
+        new SQLRunner(
+            Resources.getUserDataSource(),
+            sql,
+            "read-analysis-study"
+        ).executeQuery(
+            new Integer[]{ month, year },
+            rs -> {
+              while (rs.next()) {
+                try {
+                  tabularFormatter.write(rs.getString("dataset_id"));
+                  tabularFormatter.write(Integer.toString(rs.getInt("analysis_count")));
+                  tabularFormatter.write(Integer.toString(rs.getInt("shares_count")));
+                  tabularFormatter.nextRecord();
+                } catch (IOException e) {
+                  throw new RuntimeException("Error while attempting to write to output stream.", e);
+                }
+              }
+              return null;
+            }
+        ), EXCEPTION_HANDLER);
+  }
+
+  public void streamAggregateUserStats(int year, int month, TabularDataWriter tabularFormatter) {
+    final String categoryCol = "user_category";
+    final String numUserCol = "num_users";
+    final String numFiltersCol = "num_filters";
+    final String numAnalysesCol = "num_analyses";
+    final String numVizCol = "num_visualizations";
+    String sql = """
+        SELECT 
+          s.%s, 
+          s.%s,  
+          s.%s,
+          s.%s,
+          s.%s
+        FROM %saggregateuserstats s
+        JOIN (
+          SELECT MAX(report_id) report_id, report_month, report_year, MAX(report_time) FROM %sreports
+          GROUP BY report_id, report_month, report_year
+          HAVING report_month = ? AND report_year = ?
+        ) r 
+        ON r.report_id = s.report_id
+        """.formatted(categoryCol, numUserCol, numFiltersCol, numAnalysesCol, numVizCol,
+        _metricsReportsSchema, _metricsReportsSchema);
+    try {
+      tabularFormatter.write(categoryCol, numUserCol, numFiltersCol, numAnalysesCol, numVizCol);
+      tabularFormatter.nextRecord();
+    } catch (IOException e) {
+      throw new RuntimeException("Unable to write headers.", e);
+    }
+
+    mapException(() ->
+        new SQLRunner(
+            Resources.getUserDataSource(),
+            sql,
+            "read-analysis-totals"
+        ).executeQuery(
+            new Integer[]{ month, year },
+            rs -> {
+              while (rs.next()) {
+                try {
+                  tabularFormatter.write(rs.getString(categoryCol));
+                  tabularFormatter.write(Integer.toString(rs.getInt(numUserCol)));
+                  tabularFormatter.write(Integer.toString(rs.getInt(numFiltersCol)));
+                  tabularFormatter.write(Integer.toString(rs.getInt(numAnalysesCol)));
+                  tabularFormatter.write(Integer.toString(rs.getInt(numVizCol)));
+                  tabularFormatter.nextRecord();
+                } catch (IOException e) {
+                  throw new RuntimeException("Error while attempting to write to output stream.", e);
+                }
+              }
+              return null;
+            }
+        ), EXCEPTION_HANDLER);
+  }
+
+  public void streamDownloadReport(int year, int month, TabularDataWriter recordFormatter) {
+    final String studyIdCol = "study_id";
+    final String numUsersFullDownloadCol = "num_users_full_download";
+    final String numUsersSubsetDownloadCol = "num_users_subset_download";
+    String sql = """
+        SELECT 
+          d.%s, 
+          d.%s,  
+          d.%s
+        FROM %sdownloadsperstudy d
+        JOIN (
+          SELECT MAX(report_id) report_id, report_month, report_year, MAX(report_time) FROM %sreports
+          GROUP BY report_id, report_month, report_year
+          HAVING report_month = ? AND report_year = ?
+        ) r 
+        ON r.report_id = d.report_id
+    """.formatted(studyIdCol, numUsersFullDownloadCol, numUsersSubsetDownloadCol, _metricsReportsSchema, _metricsReportsSchema);
+
+    try {
+      recordFormatter.write(studyIdCol, numUsersFullDownloadCol, numUsersSubsetDownloadCol);
+      recordFormatter.nextRecord();
+    } catch (IOException e) {
+      throw new RuntimeException("Unable to write headers.", e);
+    }
+
+    mapException(() ->
+        new SQLRunner(
+            Resources.getUserDataSource(),
+            sql,
+            "read-download-report"
+        ).executeQuery(
+            new Integer[]{ month, year },
+            rs -> {
+              while (rs.next()) {
+                try {
+                  recordFormatter.write(rs.getString("study_id"));
+                  recordFormatter.write(Integer.toString(rs.getInt("num_users_full_download")));
+                  recordFormatter.write(Integer.toString(rs.getInt("num_users_subset_download")));
+                  recordFormatter.nextRecord();
+                } catch (IOException e) {
+                  throw new RuntimeException("Error while attempting to write to output stream.", e);
+                }
+              }
+              return null;
+            }
+        ), EXCEPTION_HANDLER);
+  }
+
+  public void streamAnalysisHistogram(int year, int month, TabularDataWriter tabularFormatter) {
+    String sql = """
+        SELECT 
+          h.count_bucket, 
+          h.registered_users_analyses,  
+          h.guests_analyses,
+          h.registered_users_filters,
+          h.guests_filters,
+          h.registered_users_visualizations,
+          h.guest_users_visualizations
+        FROM %sanalysishistogram h
+        JOIN (
+          SELECT MAX(report_id) report_id, report_month, report_year, MAX(report_time) FROM %sreports
+          GROUP BY report_id, report_month, report_year
+          HAVING report_month = ? AND report_year = ?
+        ) r 
+        ON r.report_id = h.report_id
+    """.formatted(_metricsReportsSchema, _metricsReportsSchema);
+    try {
+      tabularFormatter.write("count_bucket", "registered_users_analyses", "guests_analyses",
+          "guests_filters", "registered_users_visualizations", "guest_user_visualizations");
+      tabularFormatter.nextRecord();
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to write header rows", e);
+    }
+    mapException(() ->
+        new SQLRunner(
+            Resources.getUserDataSource(),
+            sql,
+            "read-analysis-histogram"
+        ).executeQuery(
+            new Integer[]{ month, year },
+            rs -> {
+              while (rs.next()) {
+                try {
+                  tabularFormatter.write(rs.getString("count_bucket"));
+                  tabularFormatter.write(Integer.toString(rs.getInt("registered_users_analyses")));
+                  tabularFormatter.write(Integer.toString(rs.getInt("guests_analyses")));
+                  tabularFormatter.write(Integer.toString(rs.getInt("registered_users_filters")));
+                  tabularFormatter.write(Integer.toString(rs.getInt("guests_filters")));
+                  tabularFormatter.write(Integer.toString(rs.getInt("registered_users_visualizations")));
+                  tabularFormatter.write(Integer.toString(rs.getInt("guest_users_visualizations")));
+                  tabularFormatter.nextRecord();
+                } catch (IOException e) {
+                  throw new RuntimeException(e);
+                }
+              }
+              return null;
             }
         ), EXCEPTION_HANDLER);
   }


### PR DESCRIPTION
## Overview
Now that the db permissions are in place, here's an endpoint to download usage metrics reports populated by jenkins job.

Results in dev:
||study_id|num_users_full_download|num_users_subset_download|
|-|-|-|-|
|1 |AVENIR-1|0|0|
|2|BRAZIL0001-1|0|1|
|3|INDIA0001-1|0|1|
|4|JILCOST-1|1|0|


||dataset_id|analysis_count|shares_count|
|-|-|-|-|
|1|DS_d6a1141fbf|60|0|
|2|DS_8e1f623542|25|3|
|3|DS_841a9f5259|15|0|
|4|DS_cb9893494e|9|0|
|5|DS_7c4cd6bba9|8|0|
|6|EDAUD_22881|6|6|
|7|DS_f5fc8ea2d2|6|0|
|8|DS_4d0fe88b6b|6|0|
|9|DS_450c62c7d0|4|0|
|10|DS_a885240fc4|3|0|
|11|DS_1d610aa72a|2|0|
|12|DS_def666ebb5|2|0|
|13|DS_6834a4c83b|2|0|
|14|DS_d70aacce42|2|1|
|15|EDAUD_25245|2|2|
|16|DS_6a93753102|1|0|
|17|DS_17191d35b9|1|0|
|18|DS_8e36901235|1|0|
|19|DS_f559aee789|1|0|
|20|DS_51b40fe2e2|1|0|
|21|DS_0086998c2f|1|0|
|22|DS_010e5612b8|1|0|
|23|DS_4902d9b7ec|1|0|
|24|DS_13de92039a|1|0|
|25|DS_2a6ace17a1|1|0|

||user_category|num_users|num_filters|num_analyses|num_visualizations|
|-|-|-|-|-|-|
|1|registered|8|21|45|65|
|2|guest|63|26|117|47|

||count_bucket|registered_users_analyses|guests_analyses|guests_filters|
|-|-|-|-|-|
|0|0|0|0|54|
|1|2|44|2|7|
|2|0|6|0|1|
|<=4|1|7|1|0|
|<=8|4|6|4|0|
|<=16|1|0|1|0|
|<=32|0|0|0|1|
|<=64|0|0|0|0|
|>64|0|0|0|0|

||registered_users_visualizations|guest_user_visualizations|
|-|-|-|
|0|2|30|
|1|0|24|
|2|0|5|
|<=4|1|4|
|<=8|1|0|
|<=16|3|0|
|<=32|1|0|
|<=64|0|0|
|>64|0|0